### PR TITLE
Create lists from Todo sidebar

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -34,6 +34,26 @@ Hooks.BlurOnEnter = {
   },
 };
 
+Hooks.ColorPreview = {
+  mounted() {
+    const input = this.el.querySelector('input[type="color"]');
+    const dot = this.el.querySelector('[data-preview="list-color"]');
+    if (!input || !dot) return;
+    const update = (value) => {
+      dot.style.backgroundColor = value;
+    };
+    update(input.value);
+    this._onInput = (e) => update(e.target.value);
+    input.addEventListener("input", this._onInput);
+  },
+  destroyed() {
+    const input = this.el.querySelector('input[type="color"]');
+    if (input && this._onInput) {
+      input.removeEventListener("input", this._onInput);
+    }
+  },
+};
+
 window.LiveViewHooks = Hooks;
 
 let csrfToken = document

--- a/lib/elixir_todo_web/live/todo_live/todo_live.ex
+++ b/lib/elixir_todo_web/live/todo_live/todo_live.ex
@@ -18,7 +18,9 @@ defmodule ElixirTodoWeb.TodoLive do
      |> assign(:lists, lists)
      |> assign(:selected_list, selected_list)
      |> assign(:items, items)
-     |> assign(:editing_item_id, nil)}
+     |> assign(:editing_item_id, nil)
+     |> assign(:new_list_name, "")
+     |> assign(:new_list_color, "#22c55e")}
   end
 
   @impl true
@@ -57,6 +59,28 @@ defmodule ElixirTodoWeb.TodoLive do
     {:ok, _} = Todos.delete_item(item)
     items = Todos.list_items_for_list(socket.assigns.selected_list)
     {:noreply, assign(socket, items: items)}
+  end
+
+  @impl true
+  def handle_event("create_list", %{"name" => name, "color" => color}, socket) do
+    name = String.trim(name || "")
+    color = String.trim(color || "")
+
+    if name != "" and color != "" do
+      {:ok, list} = Todos.create_list(%{name: name, color: color})
+      lists = Todos.list_lists()
+      items = Todos.list_items_for_list(list)
+
+      {:noreply,
+       socket
+       |> assign(:lists, lists)
+       |> assign(:selected_list, list)
+       |> assign(:items, items)
+       |> assign(:new_list_name, "")
+       |> assign(:new_list_color, color)}
+    else
+      {:noreply, socket}
+    end
   end
 
   @doc """

--- a/lib/elixir_todo_web/live/todo_live/todo_live.ex
+++ b/lib/elixir_todo_web/live/todo_live/todo_live.ex
@@ -83,6 +83,8 @@ defmodule ElixirTodoWeb.TodoLive do
     end
   end
 
+  
+
   @doc """
   Handles the creation of a new item when the user finishes typing in the new item input.
   """

--- a/lib/elixir_todo_web/live/todo_live/todo_live.html.heex
+++ b/lib/elixir_todo_web/live/todo_live/todo_live.html.heex
@@ -28,16 +28,15 @@
           placeholder="New list name"
           class="min-w-0 h-10 flex-1 rounded-md border border-zinc-700 bg-zinc-800 px-3 text-sm text-zinc-100 placeholder-zinc-500 focus:border-zinc-500 focus:outline-none"
         />
-        <div class="relative shrink-0 h-10">
+        <div id="new-list-color-picker" class="relative shrink-0 h-10" phx-hook="ColorPreview">
           <div class="flex h-full items-center gap-1.5 rounded-md border border-zinc-700 bg-zinc-800 px-2 text-sm text-zinc-200">
-            <span class="h-5 w-5 rounded-full border border-zinc-600" style={"background-color: #{@new_list_color};"}></span>
+            <span data-preview="list-color" class="h-5 w-5 rounded-full border border-zinc-600" style={"background-color: #{@new_list_color};"}></span>
             <.icon name="hero-chevron-down-mini" class="h-4 w-4 text-zinc-400" />
           </div>
           <input
             type="color"
             name="color"
             value={@new_list_color}
-            phx-change="preview_list_color"
             class="absolute inset-0 h-full w-full cursor-pointer opacity-0"
             aria-label="Pick list color"
           />

--- a/lib/elixir_todo_web/live/todo_live/todo_live.html.heex
+++ b/lib/elixir_todo_web/live/todo_live/todo_live.html.heex
@@ -20,22 +20,29 @@
         </li>
       <% end %>
     </ul>
-    <div class="mt-4 space-y-2">
-      <form phx-submit="create_list" class="space-y-2">
-        <input type="text"
-               name="name"
-               placeholder="New list name"
-               class="w-full rounded border border-zinc-600 bg-zinc-800 text-zinc-100 px-2 py-1" />
-        <div class="flex items-center gap-2">
-          <input type="color"
-                 name="color"
-                 value={@new_list_color}
-                 class="h-8 w-10 rounded border border-zinc-600 bg-zinc-800" />
-          <button type="submit"
-            class="rounded bg-zinc-700 px-2 py-1 text-sm hover:bg-zinc-600">
-            Add List
-          </button>
-        </div>
+    <div class="mt-4">
+      <form phx-submit="create_list" class="flex items-center gap-2">
+        <input
+          type="text"
+          name="name"
+          placeholder="New list name"
+          class="flex-1 rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:border-zinc-500 focus:outline-none"
+        />
+        <input
+          type="color"
+          name="color"
+          value={@new_list_color}
+          class="h-9 w-9 cursor-pointer rounded-md border border-zinc-700 bg-zinc-800 p-0"
+          title="List color"
+        />
+        <button
+          type="submit"
+          phx-disable-with="Adding..."
+          class="rounded-md bg-zinc-700 px-3 py-2 text-sm font-medium text-zinc-100 hover:bg-zinc-600"
+          aria-label="Add list"
+        >
+          Add
+        </button>
       </form>
     </div>
   </aside>

--- a/lib/elixir_todo_web/live/todo_live/todo_live.html.heex
+++ b/lib/elixir_todo_web/live/todo_live/todo_live.html.heex
@@ -14,6 +14,24 @@
         </li>
       <% end %>
     </ul>
+    <div class="mt-4 space-y-2">
+      <form phx-submit="create_list" class="space-y-2">
+        <input type="text"
+               name="name"
+               placeholder="New list name"
+               class="w-full rounded border border-zinc-600 bg-zinc-800 text-zinc-100 px-2 py-1" />
+        <div class="flex items-center gap-2">
+          <input type="color"
+                 name="color"
+                 value={@new_list_color}
+                 class="h-8 w-10 rounded border border-zinc-600 bg-zinc-800" />
+          <button type="submit"
+            class="rounded bg-zinc-700 px-2 py-1 text-sm hover:bg-zinc-600">
+            Add List
+          </button>
+        </div>
+      </form>
+    </div>
   </aside>
   <main class="flex-1">
     <h1 class="text-2xl mb-4" style={"color: #{@selected_list && @selected_list.color};"}>

--- a/lib/elixir_todo_web/live/todo_live/todo_live.html.heex
+++ b/lib/elixir_todo_web/live/todo_live/todo_live.html.heex
@@ -32,13 +32,13 @@
           type="color"
           name="color"
           value={@new_list_color}
-          class="h-9 w-9 cursor-pointer rounded-md border border-zinc-700 bg-zinc-800 p-0"
+          class="h-9 w-9 min-w-[2.25rem] shrink-0 cursor-pointer rounded-md border border-zinc-700 bg-zinc-800 p-0 appearance-none overflow-hidden"
           title="List color"
         />
         <button
           type="submit"
           phx-disable-with="Adding..."
-          class="rounded-md bg-zinc-700 px-3 py-2 text-sm font-medium text-zinc-100 hover:bg-zinc-600"
+          class="shrink-0 rounded-md bg-zinc-700 px-3 py-2 text-sm font-medium text-zinc-100 hover:bg-zinc-600"
           aria-label="Add list"
         >
           Add

--- a/lib/elixir_todo_web/live/todo_live/todo_live.html.heex
+++ b/lib/elixir_todo_web/live/todo_live/todo_live.html.heex
@@ -26,19 +26,26 @@
           type="text"
           name="name"
           placeholder="New list name"
-          class="min-w-0 flex-1 rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:border-zinc-500 focus:outline-none"
+          class="min-w-0 h-10 flex-1 rounded-md border border-zinc-700 bg-zinc-800 px-3 text-sm text-zinc-100 placeholder-zinc-500 focus:border-zinc-500 focus:outline-none"
         />
-        <input
-          type="color"
-          name="color"
-          value={@new_list_color}
-          class="h-8 w-8 min-w-[2rem] shrink-0 cursor-pointer rounded-md border border-zinc-700 bg-zinc-800 p-0 appearance-none overflow-hidden"
-          title="List color"
-        />
+        <div class="relative shrink-0 h-10">
+          <div class="flex h-full items-center gap-1.5 rounded-md border border-zinc-700 bg-zinc-800 px-2 text-sm text-zinc-200">
+            <span class="h-5 w-5 rounded-full border border-zinc-600" style={"background-color: #{@new_list_color};"}></span>
+            <.icon name="hero-chevron-down-mini" class="h-4 w-4 text-zinc-400" />
+          </div>
+          <input
+            type="color"
+            name="color"
+            value={@new_list_color}
+            phx-change="preview_list_color"
+            class="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+            aria-label="Pick list color"
+          />
+        </div>
         <button
           type="submit"
           phx-disable-with="Adding..."
-          class="shrink-0 rounded-md bg-zinc-700 px-2.5 py-2 text-sm font-medium text-zinc-100 hover:bg-zinc-600"
+          class="shrink-0 h-10 rounded-md bg-zinc-700 px-3 text-sm font-medium text-zinc-100 hover:bg-zinc-600 inline-flex items-center"
           aria-label="Add list"
         >
           Add

--- a/lib/elixir_todo_web/live/todo_live/todo_live.html.heex
+++ b/lib/elixir_todo_web/live/todo_live/todo_live.html.heex
@@ -26,19 +26,19 @@
           type="text"
           name="name"
           placeholder="New list name"
-          class="flex-1 rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:border-zinc-500 focus:outline-none"
+          class="min-w-0 flex-1 rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-100 placeholder-zinc-500 focus:border-zinc-500 focus:outline-none"
         />
         <input
           type="color"
           name="color"
           value={@new_list_color}
-          class="h-9 w-9 min-w-[2.25rem] shrink-0 cursor-pointer rounded-md border border-zinc-700 bg-zinc-800 p-0 appearance-none overflow-hidden"
+          class="h-8 w-8 min-w-[2rem] shrink-0 cursor-pointer rounded-md border border-zinc-700 bg-zinc-800 p-0 appearance-none overflow-hidden"
           title="List color"
         />
         <button
           type="submit"
           phx-disable-with="Adding..."
-          class="shrink-0 rounded-md bg-zinc-700 px-3 py-2 text-sm font-medium text-zinc-100 hover:bg-zinc-600"
+          class="shrink-0 rounded-md bg-zinc-700 px-2.5 py-2 text-sm font-medium text-zinc-100 hover:bg-zinc-600"
           aria-label="Add list"
         >
           Add

--- a/lib/elixir_todo_web/live/todo_live/todo_live.html.heex
+++ b/lib/elixir_todo_web/live/todo_live/todo_live.html.heex
@@ -1,15 +1,21 @@
-<div class="flex gap-4">
-  <aside>
-    <h2 class="font-bold mb-2">Lists</h2>
-    <ul>
+<div class="flex gap-6">
+  <aside class="w-64 shrink-0">
+    <h2 class="mb-3 text-xs font-semibold uppercase tracking-wide text-zinc-400">Lists</h2>
+    <ul class="space-y-1">
       <%= for list <- @lists do %>
         <li>
           <button
             phx-click="select_list"
             phx-value-id={list.id}
-            style={"color: #{list.color}; font-weight: #{@selected_list && @selected_list.id == list.id && "bold"};"}
+            class={[
+              "group flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm text-zinc-200 hover:bg-zinc-800",
+              @selected_list && @selected_list.id == list.id && "bg-zinc-800 ring-1 ring-zinc-700"
+            ]}
           >
-            <%= list.name %>
+            <span class="inline-block h-2.5 w-2.5 rounded-full" style={"background-color: #{list.color};"}></span>
+            <span class="truncate">
+              <%= list.name %>
+            </span>
           </button>
         </li>
       <% end %>
@@ -34,51 +40,61 @@
     </div>
   </aside>
   <main class="flex-1">
-    <h1 class="text-2xl mb-4" style={"color: #{@selected_list && @selected_list.color};"}>
-      <%= @selected_list && @selected_list.name %>
-    </h1>
-    <ul>
+    <div class="mb-4 flex items-center gap-3">
+      <span class="inline-block h-3 w-3 rounded-full" style={"background-color: #{@selected_list && @selected_list.color || "#71717a"};"}></span>
+      <h1 class="text-2xl font-semibold text-zinc-100">
+        <%= @selected_list && @selected_list.name || "No list selected" %>
+      </h1>
+    </div>
+    <ul class="divide-y divide-zinc-800 overflow-hidden rounded-md border border-zinc-800 bg-zinc-900/50">
       <%= for item <- @items do %>
-        <li>
-          <input type="checkbox"
-                 phx-click="toggle_item"
-                 phx-value-id={item.id}
-                 checked={item.completed} />
-
-          <%= if @editing_item_id == item.id do %>
-            <input type="text"
-                   name="text"
-                   value={item.text}
-                   phx-blur="save_edit"
+        <li class="group flex items-center justify-between px-3 py-2 hover:bg-zinc-800/60">
+          <div class="flex items-center">
+            <input type="checkbox"
+                   class="h-4 w-4 rounded border-zinc-600 text-zinc-400 focus:ring-0"
+                   phx-click="toggle_item"
                    phx-value-id={item.id}
-                   id={item.text <> "-" <> Integer.to_string(item.id)}
-                   phx-hook="BlurOnEnter"
-                   autofocus
-            />
-          <% else %>
-            <span style={item.completed && "text-decoration: line-through; cursor: pointer;"}
-                  phx-click="edit_item"
-                  phx-value-id={item.id}>
-              <%= item.text %>
-            </span>
-            <button
-              phx-click="delete_item"
-              phx-value-id={item.id}
-              class="ml-2 text-red-500 hover:text-red-300">
-              <.icon name="hero-trash-mini" class="h-4 w-4" />
-            </button>
-          <% end %>
+                   checked={item.completed} />
+
+            <%= if @editing_item_id == item.id do %>
+              <input type="text"
+                     name="text"
+                     value={item.text}
+                     phx-blur="save_edit"
+                     phx-value-id={item.id}
+                     id={item.text <> "-" <> Integer.to_string(item.id)}
+                     phx-hook="BlurOnEnter"
+                     autofocus
+                     class="ml-3 w-full bg-transparent text-zinc-100 placeholder-zinc-500 outline-none border-b border-zinc-700 focus:border-zinc-500" />
+            <% else %>
+              <span class={[
+                      "ml-3 cursor-pointer text-zinc-200",
+                      item.completed && "line-through text-zinc-500"
+                    ]}
+                    phx-click="edit_item"
+                    phx-value-id={item.id}>
+                <%= item.text %>
+              </span>
+            <% end %>
+          </div>
+          <button
+            phx-click="delete_item"
+            phx-value-id={item.id}
+            class="ml-2 text-red-400 opacity-0 transition-opacity hover:text-red-300 group-hover:opacity-100"
+            aria-label="Delete item">
+            <.icon name="hero-trash-mini" class="h-4 w-4" />
+          </button>
         </li>
       <% end %>
-      <li>
+      <li class="flex items-center px-3 py-2">
         <input type="text"
                name="new_item"
                id="new_item"
-               placeholder="Add new item..."
+               placeholder="Add a new item and hit Enter"
                phx-blur="create_item"
                phx-hook="BlurOnEnter"
                phx-value-list_id={@selected_list && @selected_list.id}
-        />
+               class="w-full rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 text-zinc-100 placeholder-zinc-500 focus:border-zinc-500 focus:outline-none" />
       </li>
     </ul>
   </main>


### PR DESCRIPTION
## Summary
- Add a create-list form (name + color) in the Todo sidebar.
- Implement `create_list` handler to persist, select the new list, and refresh items.

## Test plan
- mix test: all green.
- In the app, enter a name, pick a color, click Add List. The new list should be highlighted and items area empty.